### PR TITLE
Restore dashboard tab styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <div class="container navbar-inner">
       <div class="navbar-left site-name">Dashboard</div>
     </div>
-    <div class="tabs" id="tabsContainer">
+    <div class="tabs scroll-tabs" id="tabsContainer">
       <button class="tab-button active" data-target="geoscorePanel">GeoScore</button>
       <button class="tab-button" data-target="geolayersPanel">GeoLayers</button>
     </div>

--- a/style.css
+++ b/style.css
@@ -1059,7 +1059,7 @@ button:hover {
 /* ─────────────────────────────────────────────────────────────────────────────
    3) Tabs pulled left & higher contrast
 ───────────────────────────────────────────────────────────────────────────── */
-#goalsView .navbar .tabs {
+.navbar .tabs {
   width: 100%;
   margin: 0;
   padding: 0 8px;
@@ -1070,7 +1070,7 @@ button:hover {
   border: none;
 }
 
-#goalsView .navbar .tabs button {
+.navbar .tabs button {
   background: #ffffff !important;
   border: 1px solid #cccccc;
   border-bottom: 2px solid transparent;
@@ -1083,7 +1083,7 @@ button:hover {
   transition: background-color 0.2s ease-in-out, border-color 0.2s;
 }
 
-#goalsView .navbar .tabs button.active {
+.navbar .tabs button.active {
   background: #e4ede8 !important;
   /* subtle highlight */
   color: #000000 !important;
@@ -1092,7 +1092,7 @@ button:hover {
   font-weight: 600;
 }
 
-#goalsView .navbar .tabs button:hover:not(.active) {
+.navbar .tabs button:hover:not(.active) {
   background: #f2f2f2;
 }
 


### PR DESCRIPTION
## Summary
- Reintroduce scroll-tabs class for navbar tabs and apply generic tab styling
- Add .gitignore to exclude node_modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab963c49cc83279a3727f75f528657