### PR TITLE
Normalize city score range

### DIFF
--- a/scripts/generateGeoscoreCountryCities.js
+++ b/scripts/generateGeoscoreCountryCities.js
@@ -92,13 +92,23 @@ function allocateMentions(cities){
     return Math.min(1.2, ease);
   };
   const A = 1.0, B = 2.5, C = 0.5, D = -8.0;
-  return cities.map(c => {
+  let results = cities.map(c => {
     const pop = Math.max(1, Number(c.population)||1);
     const rr = 1/Math.sqrt(Math.max(1, rankMap.get(c.name)||1));
     const z = A*Math.log10(pop) + B*rr + C*nameEase(c.name) + D;
     const p = Math.max(0, Math.min(100, Math.round(100*sigmoid(z))));
-    return { name: cleanName(c.name), score: p, count: p };
+    return { name: cleanName(c.name), score: p };
   });
+  if(results.length){
+    const maxScore = Math.max(...results.map(r=>r.score));
+    const minScore = Math.min(...results.map(r=>r.score));
+    const range = maxScore - minScore || 1;
+    results = results.map(r=>{
+      const s = Math.round(((r.score - minScore) / range) * 100);
+      return { name: r.name, score: s, count: s };
+    });
+  }
+  return results;
 }
 
 function mergeIntoFile(existing, newQs){

--- a/scripts/generateGeoscoreWorldCitiesNe.js
+++ b/scripts/generateGeoscoreWorldCitiesNe.js
@@ -92,13 +92,23 @@ function allocScoresRecall(cities){
   };
   // Calibrated coefficients: interpret as expected recalls per 100 guesses
   const A = 1.0, B = 2.5, C = 0.5, D = -8.0; // z = A*log10(pop) + B*(1/sqrt(rank)) + C*nameEase + D
-  return cities.map(c => {
+  let results = cities.map(c => {
     const pop = Math.max(1, Number(c.population)||1);
     const rr = 1/Math.sqrt(Math.max(1, rankMap.get(c.name)||1));
     const z = A*Math.log10(pop) + B*rr + C*nameEase(c.name) + D;
     const p = Math.max(0, Math.min(100, Math.round(100*sigmoid(z))));
-    return { answer: cleanName(c.name), score: p, count: p };
+    return { answer: cleanName(c.name), score: p };
   });
+  if(results.length){
+    const maxScore = Math.max(...results.map(r=>r.score));
+    const minScore = Math.min(...results.map(r=>r.score));
+    const range = maxScore - minScore || 1;
+    results = results.map(r=>{
+      const s = Math.round(((r.score - minScore) / range) * 100);
+      return { answer: r.answer, score: s, count: s };
+    });
+  }
+  return results;
 }
 
 function mergeInto(existing, newQs){

--- a/scripts/generateStateGeoscoreFromCsv.js
+++ b/scripts/generateStateGeoscoreFromCsv.js
@@ -106,7 +106,7 @@ async function main(){
     // Tuned to push globally famous cities higher even if city-proper pop is smaller
     // Heavily weight global fame; reduce pop+rank so tail cities collapse toward 0
     const A=0.05, B=0.15, C=0.15, K=0.1, D=-2.0;
-    const answers = filtered.map((r)=>{
+    let answers = filtered.map((r)=>{
       const pop = Math.max(1, Number(r.pop2020)||1);
       const rr = 1/Math.sqrt(Math.max(1, rankMap.get(r.geoid)||1));
       const title = String(r.basename || r.NAME || '');
@@ -124,6 +124,15 @@ async function main(){
       const p = Math.max(0, Math.min(100, Math.round(100*sigmoid(z))));
       return { answer: title, score: p, count: p };
     });
+    if(answers.length){
+      const maxScore = Math.max(...answers.map(a=>a.score));
+      const minScore = Math.min(...answers.map(a=>a.score));
+      const range = maxScore - minScore || 1;
+      answers = answers.map(a=>{
+        const s = Math.round(((a.score - minScore) / range) * 100);
+        return { answer: a.answer, score: s, count: s };
+      });
+    }
     const doc = { question: `Name a city in ${STATE_NAMES[st]}`, answers };
     questions.push(doc);
   }


### PR DESCRIPTION
## Summary
- Normalize generated city scores to span 0–100 by scaling relative to min and max values within each dataset
- Apply score normalization across state, country, and world city generators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5dfa8f0fc8327b243f3bd69164793