### PR TITLE
Expand country letter questions to include all countries

### DIFF
--- a/js/geoscore.js
+++ b/js/geoscore.js
@@ -39,13 +39,17 @@ function generateCountryLetterQuestions(){
   const questions = [];
   for(const letter of letters){
     const list = (byLetter[letter] || []).sort();
-    const answers = list.slice(0,5).map((name,i)=>({
+    const answers = list.map((name,i)=>({
       answer: name,
       score: Math.max(1,10-i),
       count: Math.max(1,10-i)
     }));
     if(!answers.length){
       answers.push({ answer: 'None', score: 10, count: 10 });
+    }
+    while(answers.length < 5){
+      const i = answers.length;
+      answers.push({ answer: 'None', score: Math.max(1,10-i), count: Math.max(1,10-i) });
     }
     questions.push({
       question: `Name a country that starts with ${letter}`,


### PR DESCRIPTION
## Summary
- Remove 5-answer limit for country-by-letter GeoScore questions
- Pad lists shorter than five with placeholder answers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2d0b61083278deb96aea77709e6