### PR TITLE
Normalize geoscore question scores

### DIFF
--- a/js/geoscore.js
+++ b/js/geoscore.js
@@ -2,6 +2,33 @@ const STORAGE_KEY = 'geoscoreQuestions';
 const ANSWER_OVERRIDES_KEY = 'geoscoreAnswerOverrides';
 const EXCLUSIONS_KEY = 'geoscoreExclusions'; // { CategoryName: { normalizedName: true } }
 
+function normalizeQuestionScores(q){
+  const answers = Array.isArray(q && q.answers) ? q.answers : [];
+  const scores = answers.map(a => Number(a && a.score));
+  const valid = scores.filter(s => !isNaN(s));
+  if(!valid.length){
+    answers.forEach(a => { a.score = 100; a.count = 100; });
+    return q;
+  }
+  const min = Math.min(...valid);
+  const max = Math.max(...valid);
+  const range = max - min;
+  answers.forEach(a => {
+    let s = Number(a && a.score);
+    if(isNaN(s)) s = 100;
+    else if(range > 0) s = ((s - min) / range) * 100;
+    else s = 100;
+    s = Math.round(Math.max(0, Math.min(100, s)));
+    a.score = s;
+    a.count = s;
+  });
+  return q;
+}
+
+function normalizeAllQuestions(list){
+  (Array.isArray(list)?list:[]).forEach(normalizeQuestionScores);
+}
+
 function generateCountryLetterQuestions(){
   const countries = [
     'Afghanistan','Albania','Algeria','Andorra','Angola','Antigua and Barbuda','Argentina','Armenia','Australia','Austria','Azerbaijan',
@@ -99,6 +126,7 @@ const BASE_DEFAULT_QUESTIONS = [
 ];
 
 export const DEFAULT_QUESTIONS = BASE_DEFAULT_QUESTIONS.concat(generateCountryLetterQuestions());
+normalizeAllQuestions(DEFAULT_QUESTIONS);
 const US_STATE_SET = new Set([
   'alabama','alaska','arizona','arkansas','california','colorado','connecticut','delaware','florida','georgia',
   'hawaii','idaho','illinois','indiana','iowa','kansas','kentucky','louisiana','maine','maryland','massachusetts',
@@ -181,12 +209,14 @@ export async function loadQuestions() {
           }
         }
       }
+      normalizeAllQuestions(data);
       augmentWithCountryLetterQuestions(data);
       saveQuestions(data);
       return data;
     }
   } catch {}
   if (Array.isArray(cached) && cached.length) {
+    normalizeAllQuestions(cached);
     augmentWithCountryLetterQuestions(cached);
     return cached;
   }

--- a/tests/geoscore.test.js
+++ b/tests/geoscore.test.js
@@ -16,7 +16,7 @@ describe('geoscore persistence', () => {
     expect(await loadQuestions()).toEqual(DEFAULT_QUESTIONS);
   });
 
-  it('saves and loads answer counts', async () => {
+  it('normalizes answer scores to 0-100 range', async () => {
     const qs = [{
       question: 'Capital of France?',
       answers: [
@@ -26,8 +26,24 @@ describe('geoscore persistence', () => {
     }];
     saveQuestions(qs);
     const loaded = await loadQuestions();
-    expect(loaded[0]).toEqual(qs[0]);
+    const q = loaded.find(x => x.question === 'Capital of France?');
+    expect(q.answers[0]).toEqual({ answer: 'Paris', score: 100, count: 100 });
+    expect(q.answers[1]).toEqual({ answer: 'Lyon', score: 0, count: 0 });
     expect(loaded.length).toBeGreaterThan(qs.length);
+  });
+
+  it('defaults to 100 when all scores are equal or missing', async () => {
+    const qs = [{
+      question: 'Test uniform',
+      answers: [
+        { answer: 'A', score: 5, count: 2 },
+        { answer: 'B', score: 5, count: 1 }
+      ]
+    }];
+    saveQuestions(qs);
+    const loaded = await loadQuestions();
+    const q = loaded.find(x => x.question === 'Test uniform');
+    expect(q.answers.every(a => a.score === 100 && a.count === 100)).toBe(true);
   });
 
   it('categorizes elevation questions', () => {


### PR DESCRIPTION
## Summary
- ensure all geoscore answers are normalized to 0-100 with unknown scores treated as 100
- normalize question data on load and for default questions
- add tests covering score normalization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2aed93c8327b184103860185afe