### PR TITLE
Use tabs for GeoScore regions and expand game width

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,9 @@
       <div class="panel-header">
         <h2>GeoScore Game</h2>
       </div>
-      <div id="geoscoreGameSubtabs" style="display:flex; gap:8px; margin-bottom:8px;">
-        <button class="subtab-button active" data-mode="world">GeoScore World</button>
-        <button class="subtab-button" data-mode="us">GeoScore US</button>
+      <div id="geoscoreGameSubtabs" class="tabs" role="tablist">
+        <button role="tab" aria-selected="true" class="tab-button active" data-mode="world">World</button>
+        <button role="tab" aria-selected="false" class="tab-button" data-mode="us">US</button>
       </div>
       <div id="geoscoreGame"></div>
     </div>

--- a/js/geoscore_game.js
+++ b/js/geoscore_game.js
@@ -163,31 +163,33 @@ export async function initGeoScoreGame(){
   startBtn.addEventListener('click', buildRound);
   scoreEl.textContent = 'Score: 0';
 
-  if(tabs){
-    tabs.querySelectorAll('.subtab-button').forEach(btn=>{
-      btn.addEventListener('click', ()=>{
-        tabs.querySelectorAll('.subtab-button').forEach(b=>b.classList.remove('active'));
-        btn.classList.add('active');
-        currentGameType = (btn.dataset.mode==='us') ? 'state' : 'country';
-        grid.innerHTML=''; total=0; answered=0; scoreEl.textContent='Score: 0';
-        try{
-          const url = new URL(location.href);
-          url.searchParams.set('gs', btn.dataset.mode);
-          history.replaceState({ tab:'geoscoreGame', gs: btn.dataset.mode }, '', url);
-        }catch{}
+    if(tabs){
+      tabs.querySelectorAll('.tab-button').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          tabs.querySelectorAll('.tab-button').forEach(b=>{ b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
+          btn.classList.add('active');
+          btn.setAttribute('aria-selected','true');
+          currentGameType = (btn.dataset.mode==='us') ? 'state' : 'country';
+          grid.innerHTML=''; total=0; answered=0; scoreEl.textContent='Score: 0';
+          try{
+            const url = new URL(location.href);
+            url.searchParams.set('gs', btn.dataset.mode);
+            history.replaceState({ tab:'geoscoreGame', gs: btn.dataset.mode }, '', url);
+          }catch{}
+        });
       });
-    });
-    try{
-      const params = new URLSearchParams(location.search);
-      const gs = params.get('gs');
-      const initBtn = tabs.querySelector(`.subtab-button[data-mode="${gs}"]`) || tabs.querySelector('.subtab-button[data-mode="world"]');
-      if(initBtn){
-        tabs.querySelectorAll('.subtab-button').forEach(b=>b.classList.remove('active'));
-        initBtn.classList.add('active');
-        currentGameType = (initBtn.dataset.mode==='us') ? 'state' : 'country';
-      }
-    }catch{}
-  }
+      try{
+        const params = new URLSearchParams(location.search);
+        const gs = params.get('gs');
+        const initBtn = tabs.querySelector(`.tab-button[data-mode="${gs}"]`) || tabs.querySelector('.tab-button[data-mode="world"]');
+        if(initBtn){
+          tabs.querySelectorAll('.tab-button').forEach(b=>{ b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
+          initBtn.classList.add('active');
+          initBtn.setAttribute('aria-selected','true');
+          currentGameType = (initBtn.dataset.mode==='us') ? 'state' : 'country';
+        }
+      }catch{}
+    }
 
   mount.dataset.initialized = '1';
 }

--- a/style.css
+++ b/style.css
@@ -1190,6 +1190,47 @@ h2 {
   color: #333;
 }
 
+#geoscoreGamePanel.main-layout {
+  justify-content: flex-start !important;
+  max-width: none !important;
+  margin: 0 !important;
+  width: 100% !important;
+}
+
+#geoscoreGamePanel .full-column {
+  flex: 1 1 100%;
+}
+
+#geoscoreGameSubtabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #cccccc;
+}
+
+#geoscoreGameSubtabs .tab-button {
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  border-radius: 0;
+  padding: 6px 12px;
+  font-size: 0.9rem;
+  color: #555;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+#geoscoreGameSubtabs .tab-button.active {
+  color: #000;
+  border-bottom-color: #7aa68c;
+  font-weight: 600;
+}
+
+#geoscoreGameSubtabs .tab-button:hover:not(.active) {
+  color: #000;
+  background: none;
+}
+
 #metricsPanel.main-layout {
   justify-content: flex-start !important;
   max-width: none !important;


### PR DESCRIPTION
## Summary
- Replace GeoScore region buttons with accessible tabs for World vs US
- Allow GeoScore game panel to span full screen width on desktop while staying mobile friendly
- Style new region tabs for active state and hover feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e7be33c08327ac0d6c3764190428