### PR TITLE
feat: scale geoscore city maxima

### DIFF
--- a/js/geoscore.js
+++ b/js/geoscore.js
@@ -4,20 +4,9 @@ const EXCLUSIONS_KEY = 'geoscoreExclusions'; // { CategoryName: { normalizedName
 
 function normalizeQuestionScores(q){
   const answers = Array.isArray(q && q.answers) ? q.answers : [];
-  const scores = answers.map(a => Number(a && a.score));
-  const valid = scores.filter(s => !isNaN(s));
-  if(!valid.length){
-    answers.forEach(a => { a.score = 100; a.count = 100; });
-    return q;
-  }
-  const min = Math.min(...valid);
-  const max = Math.max(...valid);
-  const range = max - min;
   answers.forEach(a => {
     let s = Number(a && a.score);
-    if(isNaN(s)) s = 100;
-    else if(range > 0) s = ((s - min) / range) * 100;
-    else s = 100;
+    if(!isFinite(s)) s = 100;
     s = Math.round(Math.max(0, Math.min(100, s)));
     a.score = s;
     a.count = s;

--- a/scripts/generateGeoscoreCountryCities.js
+++ b/scripts/generateGeoscoreCountryCities.js
@@ -75,6 +75,11 @@ function cleanName(name){
   return n;
 }
 
+function maxScoreForCount(n){
+  const capped = Math.min(Math.max(n, 0), 10);
+  return 70 + Math.round((capped / 10) * 25);
+}
+
 function allocateMentions(cities){
   if(!cities.length){ return []; }
   // Recall-like independent probabilities (per 100 guesses), not normalized to sum
@@ -100,11 +105,12 @@ function allocateMentions(cities){
     return { name: cleanName(c.name), score: p };
   });
   if(results.length){
-    const maxScore = Math.max(...results.map(r=>r.score));
-    const minScore = Math.min(...results.map(r=>r.score));
-    const range = maxScore - minScore || 1;
+    const maxRaw = Math.max(...results.map(r=>r.score));
+    const minRaw = Math.min(...results.map(r=>r.score));
+    const range = maxRaw - minRaw || 1;
+    const maxScore = maxScoreForCount(results.length);
     results = results.map(r=>{
-      const s = Math.round(((r.score - minScore) / range) * 100);
+      const s = Math.round(((r.score - minRaw) / range) * maxScore);
       return { name: r.name, score: s, count: s };
     });
   }

--- a/scripts/generateGeoscoreWorldCitiesNe.js
+++ b/scripts/generateGeoscoreWorldCitiesNe.js
@@ -74,6 +74,11 @@ function cleanName(name){
   return n;
 }
 
+function maxScoreForCount(n){
+  const capped = Math.min(Math.max(n, 0), 10);
+  return 70 + Math.round((capped / 10) * 25);
+}
+
 function allocScoresRecall(cities){
   if(!cities.length) return [];
   // Rank within country
@@ -100,11 +105,12 @@ function allocScoresRecall(cities){
     return { answer: cleanName(c.name), score: p };
   });
   if(results.length){
-    const maxScore = Math.max(...results.map(r=>r.score));
-    const minScore = Math.min(...results.map(r=>r.score));
-    const range = maxScore - minScore || 1;
+    const maxRaw = Math.max(...results.map(r=>r.score));
+    const minRaw = Math.min(...results.map(r=>r.score));
+    const range = maxRaw - minRaw || 1;
+    const maxScore = maxScoreForCount(results.length);
     results = results.map(r=>{
-      const s = Math.round(((r.score - minScore) / range) * 100);
+      const s = Math.round(((r.score - minRaw) / range) * maxScore);
       return { answer: r.answer, score: s, count: s };
     });
   }

--- a/scripts/generateStateGeoscoreFromCsv.js
+++ b/scripts/generateStateGeoscoreFromCsv.js
@@ -61,6 +61,11 @@ function parseCSV(text){
 
 const sigmoid = (z)=> 1/(1+Math.exp(-z));
 
+function maxScoreForCount(n){
+  const capped = Math.min(Math.max(n, 0), 10);
+  return 70 + Math.round((capped / 10) * 25);
+}
+
 async function main(){
   const argv = process.argv.slice(2);
   const minPopArg = argv.find(a=>a.startsWith('--min-pop='));
@@ -125,11 +130,12 @@ async function main(){
       return { answer: title, score: p, count: p };
     });
     if(answers.length){
-      const maxScore = Math.max(...answers.map(a=>a.score));
-      const minScore = Math.min(...answers.map(a=>a.score));
-      const range = maxScore - minScore || 1;
+      const maxRaw = Math.max(...answers.map(a=>a.score));
+      const minRaw = Math.min(...answers.map(a=>a.score));
+      const range = maxRaw - minRaw || 1;
+      const maxScore = maxScoreForCount(answers.length);
       answers = answers.map(a=>{
-        const s = Math.round(((a.score - minScore) / range) * 100);
+        const s = Math.round(((a.score - minRaw) / range) * maxScore);
         return { answer: a.answer, score: s, count: s };
       });
     }

--- a/tests/geoscore.test.js
+++ b/tests/geoscore.test.js
@@ -16,7 +16,7 @@ describe('geoscore persistence', () => {
     expect(await loadQuestions()).toEqual(DEFAULT_QUESTIONS);
   });
 
-  it('normalizes answer scores to 0-100 range', async () => {
+  it('clamps answer scores to 0-100 range', async () => {
     const qs = [{
       question: 'Capital of France?',
       answers: [
@@ -27,12 +27,12 @@ describe('geoscore persistence', () => {
     saveQuestions(qs);
     const loaded = await loadQuestions();
     const q = loaded.find(x => x.question === 'Capital of France?');
-    expect(q.answers[0]).toEqual({ answer: 'Paris', score: 100, count: 100 });
+    expect(q.answers[0]).toEqual({ answer: 'Paris', score: 1, count: 1 });
     expect(q.answers[1]).toEqual({ answer: 'Lyon', score: 0, count: 0 });
     expect(loaded.length).toBeGreaterThan(qs.length);
   });
 
-  it('defaults to 100 when all scores are equal or missing', async () => {
+  it('retains scores when all are equal', async () => {
     const qs = [{
       question: 'Test uniform',
       answers: [
@@ -43,7 +43,7 @@ describe('geoscore persistence', () => {
     saveQuestions(qs);
     const loaded = await loadQuestions();
     const q = loaded.find(x => x.question === 'Test uniform');
-    expect(q.answers.every(a => a.score === 100 && a.count === 100)).toBe(true);
+    expect(q.answers.every(a => a.score === 5 && a.count === 5)).toBe(true);
   });
 
   it('categorizes elevation questions', () => {


### PR DESCRIPTION
## Summary
- scale city scores with a 95 point ceiling that lowers for countries or states with fewer cities
- clamp geoscore values instead of normalizing to 0-100
- adjust geoscore tests for new clamping behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f4555cc48327ac8830b36a7758cb