### PR TITLE
Prevent subtabs from blanking GeoGame panels

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,5 +1,6 @@
 function initTabs() {
-  const buttons = Array.from(document.querySelectorAll('.tab-button'));
+  // Only select top-level tab buttons that control main panels
+  const buttons = Array.from(document.querySelectorAll('.tab-button[data-target]'));
   const panels = {
     geoscorePanel: document.getElementById('geoscorePanel'),
     geoscoreGamePanel: document.getElementById('geoscoreGamePanel'),
@@ -19,6 +20,7 @@ function initTabs() {
   const paramToId = (p) => (p === 'geolayers' ? 'geolayersPanel' : (p==='geoscoreGame'?'geoscoreGamePanel':'geoscorePanel'));
 
   function setActive(targetId, push) {
+    if (!panels[targetId]) return;
     // Update tab styles and panels
     buttons.forEach(b => b.classList.toggle('active', b.dataset.target === targetId));
     Object.entries(panels).forEach(([id, el]) => {

--- a/tests/tabs.test.js
+++ b/tests/tabs.test.js
@@ -1,0 +1,33 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import '../js/tabs.js';
+
+describe('main tab behavior', () => {
+  it('ignores clicks on subtabs without data-target', () => {
+    document.body.innerHTML = `
+      <nav>
+        <div id="tabsContainer">
+          <button class="tab-button" data-target="geoscorePanel">GeoScore Admin</button>
+          <button class="tab-button" data-target="geoscoreGamePanel">GeoScore Game</button>
+          <button class="tab-button" data-target="geolayersPanel">GeoLayers</button>
+        </div>
+      </nav>
+      <section id="geoscorePanel"></section>
+      <section id="geoscoreGamePanel" style="display:none;">
+        <div id="geoscoreGameSubtabs">
+          <button class="tab-button" data-mode="world">World</button>
+          <button class="tab-button" data-mode="us">US</button>
+        </div>
+      </section>
+      <section id="geolayersPanel" style="display:none;"></section>
+    `;
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const mainVisibleBefore = document.getElementById('geoscorePanel').style.display;
+
+    document.querySelector('#geoscoreGameSubtabs .tab-button').click();
+
+    const mainVisibleAfter = document.getElementById('geoscorePanel').style.display;
+    expect(mainVisibleAfter).toBe(mainVisibleBefore);
+  });
+});


### PR DESCRIPTION
## Summary
- Limit tab initialisation to buttons with `data-target` so subtabs don't trigger panel hiding
- Guard against unknown target ids when switching tabs
- Add regression test to ensure subtabs do not affect main panels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f4d8325c832790f061f732b58e22