### PR TITLE
Add production migration plan

### DIFF
--- a/PRODUCTION_DEPLOYMENT_PLAN.md
+++ b/PRODUCTION_DEPLOYMENT_PLAN.md
@@ -1,0 +1,49 @@
+# Migration Plan: GitHub Pages to Production Server
+
+This document outlines a step-by-step plan for moving the geographical games project from GitHub Pages to a production server capable of hosting large data files and handling significant traffic.
+
+## 1. Assess Current Application
+1. **Inventory Static Assets and Data**: catalogue existing assets (maps, JSON datasets, images) and their sizes.
+2. **Review Backend Requirements**: identify APIs (Firebase, Express server) that need server-side hosting.
+3. **Audit Performance**: record baseline page load times and bandwidth usage on GitHub Pages.
+
+## 2. Choose Hosting Infrastructure
+1. **Select Cloud Provider**: evaluate AWS, GCP, or Azure based on cost, familiarity, and regional availability.
+2. **Provision Compute Resources**: choose an autoscaling environment (e.g., AWS EC2 with Auto Scaling, GCP Compute Engine, or managed container services like AWS ECS/Fargate or Cloud Run) that supports Node.js and Express.
+3. **Configure Storage for Large Data**: store large datasets in object storage (AWS S3, GCP Cloud Storage) or a CDN-backed bucket for efficient distribution.
+
+## 3. Set Up CI/CD Pipeline
+1. **Containerize the App**: create a Dockerfile for consistent builds.
+2. **Automate Builds**: configure GitHub Actions or another CI service to run tests and build the Docker image on push.
+3. **Deploy to Server**: push the image to a container registry (GitHub Container Registry, ECR, GCR) and trigger deployment to the production environment.
+
+## 4. Configure Application Server
+1. **Install Dependencies**: ensure Node.js, npm, and required system packages are installed.
+2. **Serve Static Content**: configure Express or a reverse proxy (Nginx) to serve static files and proxy API requests.
+3. **Environment Variables**: store secrets (API keys, database URLs) securely using the provider's secret manager.
+
+## 5. Optimize for High Traffic
+1. **Enable CDN**: front the application with a CDN (CloudFront, Cloudflare) to cache static assets and reduce latency.
+2. **Use Caching**: implement in-memory caching (Redis, Memcached) for frequent queries and geographic data.
+3. **Load Testing**: run tools like k6 or Artillery to simulate heavy traffic and adjust scaling thresholds.
+
+## 6. Handle Large Data Files
+1. **Chunk and Stream Data**: break large datasets into manageable chunks or provide streaming endpoints.
+2. **Background Processing**: offload heavy computations to serverless functions or worker queues.
+3. **Data Backup and Versioning**: store datasets in versioned buckets and schedule backups.
+
+## 7. Monitoring and Logging
+1. **Set Up Observability**: integrate logging (e.g., CloudWatch, Stackdriver) and metrics collection (Prometheus, Datadog).
+2. **Alerting**: configure alerts for error rates, latency, and resource utilization.
+3. **Regular Audits**: periodically review logs and performance metrics to ensure the system meets SLA targets.
+
+## 8. Cutover and Rollback Plan
+1. **Stage Environment**: deploy to a staging server mirroring production for final verification.
+2. **DNS Switch**: update domain DNS records to point from GitHub Pages to the new server.
+3. **Rollback Strategy**: retain GitHub Pages deployment or previous server snapshot for quick rollback if issues arise.
+
+## 9. Post-Migration Tasks
+1. **Documentation**: update README and deployment docs with new instructions.
+2. **User Communication**: notify users of downtime or changes.
+3. **Continuous Improvement**: monitor, optimize, and iterate on infrastructure as usage grows.
+


### PR DESCRIPTION
## Summary
- add step-by-step plan for migrating from GitHub Pages to a production-grade server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa0808ec83279e5336490294758a