### PR TITLE
style: ensure geolayers country list uses black text

### DIFF
--- a/style.css
+++ b/style.css
@@ -1265,6 +1265,7 @@ h2 {
   text-align: left;
   border: none;
   background: transparent;
+  color: #000;
   padding: 4px;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- enforce black text for GeoLayers admin country list for readability

## Testing
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_68b5fad8bcb88327befef93f2cfc1da1