### PR TITLE
Add world capitals mode to GeoScore

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       <div id="geoscoreGameSubtabs" class="tabs" role="tablist">
         <button role="tab" aria-selected="true" class="tab-button active" data-mode="world">World</button>
         <button role="tab" aria-selected="false" class="tab-button" data-mode="us">US</button>
+        <button role="tab" aria-selected="false" class="tab-button" data-mode="capitals">World Capitals</button>
       </div>
       <div id="geoscoreGame"></div>
     </div>

--- a/js/geoscore_game.js
+++ b/js/geoscore_game.js
@@ -117,7 +117,7 @@ function isUSStateName(name){
   ]);
   return set.has(n);
 }
-function categorizeQuestion(q){
+export function categorizeQuestion(q){
   const qraw = String(q && q.question || '');
   const m = /^\s*Name a city in\s+(.+)$/i.exec(qraw);
   if(m && m[1]){
@@ -134,6 +134,7 @@ function categorizeQuestion(q){
     }
     return 'country';
   }
+  if(/^\s*Name a world capital city beginning with the letter [a-z]/i.test(qraw)) return 'capital';
   return 'other';
 }
 
@@ -146,8 +147,8 @@ export async function initGeoScoreGame(){
   const tabs = document.getElementById('geoscoreGameSubtabs');
 
   const all = await loadQuestions();
-  const byType = { country: [], state: [] };
-  all.forEach(q=>{ const t=categorizeQuestion(q); if(t==='country') byType.country.push(q); else if(t==='state') byType.state.push(q); });
+  const byType = { country: [], state: [], capital: [] };
+  all.forEach(q=>{ const t=categorizeQuestion(q); if(t==='country') byType.country.push(q); else if(t==='state') byType.state.push(q); else if(t==='capital') byType.capital.push(q); });
 
   const header = document.createElement('div');
   const scoreEl = document.createElement('div');
@@ -188,7 +189,7 @@ export async function initGeoScoreGame(){
           tabs.querySelectorAll('.tab-button').forEach(b=>{ b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
           btn.classList.add('active');
           btn.setAttribute('aria-selected','true');
-          currentGameType = (btn.dataset.mode==='us') ? 'state' : 'country';
+          currentGameType = (btn.dataset.mode==='us') ? 'state' : (btn.dataset.mode==='capitals' ? 'capital' : 'country');
           grid.innerHTML=''; total=0; answered=0; scoreEl.textContent='Score: 0';
           try{
             const url = new URL(location.href);
@@ -205,7 +206,7 @@ export async function initGeoScoreGame(){
           tabs.querySelectorAll('.tab-button').forEach(b=>{ b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
           initBtn.classList.add('active');
           initBtn.setAttribute('aria-selected','true');
-          currentGameType = (initBtn.dataset.mode==='us') ? 'state' : 'country';
+          currentGameType = (initBtn.dataset.mode==='us') ? 'state' : (initBtn.dataset.mode==='capitals' ? 'capital' : 'country');
         }
       }catch{}
     }

--- a/tests/geoscore_game_category.test.js
+++ b/tests/geoscore_game_category.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { categorizeQuestion } from '../js/geoscore_game.js';
+
+describe('geoscore game categorization', () => {
+  it('categorizes world capital letter questions', () => {
+    const q = { question: 'Name a world capital city beginning with the letter B' };
+    expect(categorizeQuestion(q)).toBe('capital');
+  });
+});

--- a/tests/tabs.test.js
+++ b/tests/tabs.test.js
@@ -17,6 +17,7 @@ describe('main tab behavior', () => {
         <div id="geoscoreGameSubtabs">
           <button class="tab-button" data-mode="world">World</button>
           <button class="tab-button" data-mode="us">US</button>
+          <button class="tab-button" data-mode="capitals">World Capitals</button>
         </div>
       </section>
       <section id="geolayersPanel" style="display:none;"></section>


### PR DESCRIPTION
## Summary
- Add a "World Capitals" tab to the GeoScore game UI
- Categorize world capital letter questions and support new game mode
- Test world capital categorization and update existing tab tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fb348b688327bdbdb6fbcd62c7ab