### PR TITLE
Fix GeoScore world tab classification for country questions

### DIFF
--- a/js/geoscore_game.js
+++ b/js/geoscore_game.js
@@ -1,4 +1,4 @@
-import { loadQuestions, categorizeQuestion } from './geoscore.js';
+import { loadQuestions } from './geoscore.js';
 
 let usCitiesPromise;
 async function getUsCities(){
@@ -134,6 +134,7 @@ export function categorizeQuestion(q){
     }
     return 'country';
   }
+  if(/^\s*Name a country\b/i.test(qraw)) return 'country';
   if(/^\s*Name a world capital city beginning with the letter [a-z]/i.test(qraw)) return 'capital';
   return 'other';
 }


### PR DESCRIPTION
## Summary
- Ensure GeoScore game categorizes country prompts so world tab shows questions
- Remove unused `categorizeQuestion` import in `geoscore_game.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ff8e80948327a992ca2344a4ab05