### PR TITLE
Clamp GeoScore answer scores to 95

### DIFF
--- a/js/geoscore.js
+++ b/js/geoscore.js
@@ -6,8 +6,9 @@ function normalizeQuestionScores(q){
   const answers = Array.isArray(q && q.answers) ? q.answers : [];
   answers.forEach(a => {
     let s = Number(a && a.score);
-    if(!isFinite(s)) s = 100;
-    s = Math.round(Math.max(0, Math.min(100, s)));
+    if(!isFinite(s)) s = 95;
+    // Clamp scores between 0 (unknown) and 95 (very common)
+    s = Math.round(Math.max(0, Math.min(95, s)));
     a.score = s;
     a.count = s;
   });

--- a/tests/geoscore.test.js
+++ b/tests/geoscore.test.js
@@ -16,18 +16,18 @@ describe('geoscore persistence', () => {
     expect(await loadQuestions()).toEqual(DEFAULT_QUESTIONS);
   });
 
-  it('clamps answer scores to 0-100 range', async () => {
+  it('clamps answer scores to 0-95 range', async () => {
     const qs = [{
       question: 'Capital of France?',
       answers: [
-        { answer: 'Paris', score: 1, count: 2 },
-        { answer: 'Lyon', score: 0, count: 1 }
+        { answer: 'Paris', score: 200, count: 200 },
+        { answer: 'Lyon', score: -5, count: -5 }
       ]
     }];
     saveQuestions(qs);
     const loaded = await loadQuestions();
     const q = loaded.find(x => x.question === 'Capital of France?');
-    expect(q.answers[0]).toEqual({ answer: 'Paris', score: 1, count: 1 });
+    expect(q.answers[0]).toEqual({ answer: 'Paris', score: 95, count: 95 });
     expect(q.answers[1]).toEqual({ answer: 'Lyon', score: 0, count: 0 });
     expect(loaded.length).toBeGreaterThan(qs.length);
   });


### PR DESCRIPTION
## Summary
- limit GeoScore answers to a 0-95 range
- test score clamping at new maximum

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60191ed648327ae071cef477817cd