### PR TITLE
Combine world and capitals GeoScore tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
       <div id="geoscoreGameSubtabs" class="tabs" role="tablist">
         <button role="tab" aria-selected="true" class="tab-button active" data-mode="world">World</button>
         <button role="tab" aria-selected="false" class="tab-button" data-mode="us">US</button>
-        <button role="tab" aria-selected="false" class="tab-button" data-mode="capitals">World Capitals</button>
       </div>
       <div id="geoscoreGame"></div>
     </div>

--- a/js/geoscore_game.js
+++ b/js/geoscore_game.js
@@ -149,8 +149,12 @@ export async function initGeoScoreGame(){
 
   const all = await loadQuestions();
 
-  const byType = { country: [], state: [], capital: [] };
-  all.forEach(q=>{ const t=categorizeQuestion(q); if(t==='country') byType.country.push(q); else if(t==='state') byType.state.push(q); else if(t==='capital') byType.capital.push(q); });
+  const byType = { country: [], state: [] };
+  all.forEach(q=>{
+    const t = categorizeQuestion(q);
+    if(t === 'state') byType.state.push(q);
+    else if(t === 'country' || t === 'capital') byType.country.push(q);
+  });
 
 
   const header = document.createElement('div');
@@ -192,7 +196,7 @@ export async function initGeoScoreGame(){
           tabs.querySelectorAll('.tab-button').forEach(b=>{ b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
           btn.classList.add('active');
           btn.setAttribute('aria-selected','true');
-          currentGameType = (btn.dataset.mode==='us') ? 'state' : (btn.dataset.mode==='capitals' ? 'capital' : 'country');
+          currentGameType = (btn.dataset.mode==='us') ? 'state' : 'country';
           grid.innerHTML=''; total=0; answered=0; scoreEl.textContent='Score: 0';
           try{
             const url = new URL(location.href);
@@ -209,7 +213,7 @@ export async function initGeoScoreGame(){
           tabs.querySelectorAll('.tab-button').forEach(b=>{ b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
           initBtn.classList.add('active');
           initBtn.setAttribute('aria-selected','true');
-          currentGameType = (initBtn.dataset.mode==='us') ? 'state' : (initBtn.dataset.mode==='capitals' ? 'capital' : 'country');
+          currentGameType = (initBtn.dataset.mode==='us') ? 'state' : 'country';
         }
       }catch{}
     }

--- a/tests/tabs.test.js
+++ b/tests/tabs.test.js
@@ -17,7 +17,6 @@ describe('main tab behavior', () => {
         <div id="geoscoreGameSubtabs">
           <button class="tab-button" data-mode="world">World</button>
           <button class="tab-button" data-mode="us">US</button>
-          <button class="tab-button" data-mode="capitals">World Capitals</button>
         </div>
       </section>
       <section id="geolayersPanel" style="display:none;"></section>


### PR DESCRIPTION
## Summary
- Merge World and World Capitals GeoScore modes into one World tab
- Update GeoScore game logic to include capital questions in world pool
- Adjust tests and HTML to remove separate capitals subtab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b760b84bec8327ba8519791f7ede45